### PR TITLE
Handle unknown node readiness

### DIFF
--- a/controllers/openstacksre_controller.go
+++ b/controllers/openstacksre_controller.go
@@ -72,7 +72,7 @@ func (r *OpenStackSREReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	//    (In a real scenario, you'd map K8s node to an OpenStack hypervisor.)
 	downHypervisors := []corev1.Node{}
 	for _, node := range nodeList.Items {
-		if isNodeDown(&node) {
+		if IsNodeDown(&node) {
 			downHypervisors = append(downHypervisors, node)
 		}
 	}
@@ -134,14 +134,20 @@ func getOpenStackProvider() (*gophercloud.ProviderClient, error) {
 	return provider, nil
 }
 
-// isNodeDown - simplistic check if Node is "NotReady". In production, refine this.
-func isNodeDown(node *corev1.Node) bool {
+// IsNodeDown checks if a node should be considered down based on its Ready
+// condition. It returns true when the Ready condition is False or Unknown, or
+// when no Ready condition is present at all.
+func IsNodeDown(node *corev1.Node) bool {
+	found := false
 	for _, cond := range node.Status.Conditions {
-		if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionFalse {
-			return true
+		if cond.Type == corev1.NodeReady {
+			found = true
+			if cond.Status == corev1.ConditionFalse || cond.Status == corev1.ConditionUnknown {
+				return true
+			}
 		}
 	}
-	return false
+	return !found
 }
 
 // evacuateHypervisor calls "server evacuate" on each instance in the down hypervisor

--- a/internal/controller/openstacksre_controller_test.go
+++ b/internal/controller/openstacksre_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openstackv1alpha1 "github.com/skotnicky/openstack-sre-operator/api/v1alpha1"
+	controllerspkg "github.com/skotnicky/openstack-sre-operator/controllers"
 )
 
 var _ = Describe("OpenStackSRE Controller", func() {
@@ -79,6 +81,27 @@ var _ = Describe("OpenStackSRE Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+
+		Context("isNodeDown helper", func() {
+			It("returns true for ConditionUnknown", func() {
+				node := corev1.Node{
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionUnknown,
+							},
+						},
+					},
+				}
+				Expect(controllerspkg.IsNodeDown(&node)).To(BeTrue())
+			})
+
+			It("returns true when Ready condition missing", func() {
+				node := corev1.Node{}
+				Expect(controllerspkg.IsNodeDown(&node)).To(BeTrue())
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- mark nodes down if Ready status Unknown or missing
- test the new IsNodeDown behavior

## Testing
- `go build ./...` *(fails: context deadline or hang?)*