### PR TITLE
Fix vet compile error

### DIFF
--- a/internal/controller/openstacksre_controller_test.go
+++ b/internal/controller/openstacksre_controller_test.go
@@ -148,18 +148,18 @@ var _ = Describe("OpenStackSRE Controller", func() {
 	})
 
 	var _ = Describe("Balancing logic", func() {
-		It("selects hosts when difference exceeds threshold", func() {
-			hosts := []hypervisorInfo{
-				{Hypervisor: hypervisors.Hypervisor{HypervisorHostname: "hv1", RunningVMs: 10}, AZ: "nova"},
-				{Hypervisor: hypervisors.Hypervisor{HypervisorHostname: "hv2", RunningVMs: 2}, AZ: "nova"},
-			}
-			src, dst, ok := selectMigrationPair(hosts, 5)
-			Expect(ok).To(BeTrue())
-			Expect(src.HypervisorHostname).To(Equal("hv1"))
-			Expect(dst.HypervisorHostname).To(Equal("hv2"))
+               It("selects hosts when difference exceeds threshold", func() {
+                       hosts := []controllerspkg.HypervisorInfo{
+                               {Hypervisor: hypervisors.Hypervisor{HypervisorHostname: "hv1", RunningVMs: 10}, AZ: "nova"},
+                               {Hypervisor: hypervisors.Hypervisor{HypervisorHostname: "hv2", RunningVMs: 2}, AZ: "nova"},
+                       }
+                       src, dst, ok := controllerspkg.SelectMigrationPair(hosts, 5)
+                       Expect(ok).To(BeTrue())
+                       Expect(src.HypervisorHostname).To(Equal("hv1"))
+                       Expect(dst.HypervisorHostname).To(Equal("hv2"))
 
-			_, _, ok = selectMigrationPair(hosts, 20)
-			Expect(ok).To(BeFalse())
-		})
+                       _, _, ok = controllerspkg.SelectMigrationPair(hosts, 20)
+                       Expect(ok).To(BeFalse())
+               })
 	})
 })


### PR DESCRIPTION
## Summary
- alias `HypervisorInfo` for external use
- expose `SelectMigrationPair` via wrapper
- adjust controller tests to use exported names

## Testing
- `go vet ./...` *(fails: connect: no route to host)*